### PR TITLE
fix(ChannelCard): handle broken image

### DIFF
--- a/components/ChannelCard.tsx
+++ b/components/ChannelCard.tsx
@@ -111,6 +111,9 @@ function ChannelCard(props: ChannelCardProps & ExtraCardsProps) {
                                     className={`w-full object-cover object-center rounded-t-lg ${
                                         is_retired && "opacity-50"
                                     }`}
+                                    onError={(e) => {
+                                        e.currentTarget.src = "https://avatars.githubusercontent.com/u/73813619?s=200&v=4";
+                                    }}
                                 />
                             </a>
                         </Link>

--- a/pages/channel/[chid].tsx
+++ b/pages/channel/[chid].tsx
@@ -334,6 +334,9 @@ export default class ChannelPageInfo extends React.Component<ChannelPageInfoProp
                                     className={"rounded-full mx-auto h-64 " + borderName}
                                     src={image}
                                     loading="lazy"
+                                    onError={(e) => {
+                                        e.currentTarget.src = "https://avatars.githubusercontent.com/u/73813619?s=200&v=4";
+                                    }}
                                 />
                             </a>
                         </div>


### PR DESCRIPTION
I completely understand the API probably outdated and does not sync to each vtuber avatar, instead consuming image which is broke, I would prefer use IHA avatar to handle them, especially plenty of twitter avatar were fail

before: https://prnt.sc/mSuYU5PJtd0R
after: https://prnt.sc/Wa5VEv8Ebcjf